### PR TITLE
Remove proxyquire from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "url": "https://github.com/Kevnz/pxpay/issues"
   },
   "dependencies": {
-    "proxyquire": "^1.7.3",
     "request": "^2.74.0",
     "xml": "^1.0.1",
     "xml2js": "^0.4.17"
@@ -37,7 +36,7 @@
     "chai": "~1.9.0",
     "mocha": "^1.13.0",
     "nyc": "^8.1.0",
-    "proxyquire": "^1.3.1",
+    "proxyquire": "^1.7.3",
     "xmldom": "~0.1.16",
     "xpath": "0.0.5"
   }


### PR DESCRIPTION
It seems to only be used in tests so should be a `devDependency`.